### PR TITLE
Fixes infinite loop while "stacking" store instances

### DIFF
--- a/src/patches/StorePatch.ts
+++ b/src/patches/StorePatch.ts
@@ -32,6 +32,7 @@ const History: {
 
 export function patchStore(serverApi: ServerAPI): () => void {
   if (History && History.listen) {
+    let oldUrl = "";
     const unlisten = History.listen(async (info) => {
       try {
         if (info.pathname === '/steamweb') {
@@ -58,7 +59,6 @@ export function patchStore(serverApi: ServerAPI): () => void {
         tab.url.includes('https://isthereanydeal.com')
       );
 
-      let oldUrl = "";
       if (itadTab) {
         oldUrl = "" // This is necessary so that the appID will be set again after closing the external browser
         setTimeout(() => getCurrentAppID(), 1500)


### PR DESCRIPTION
When opening a game through the store page and then switching to the store via the sidebar the plugin goes into an infinite loop. This fixes it and the bug #11 