### PR TITLE
fix: stop log spamming from plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ class Plugin:
         )
 
     async def settings_load(self, key: str, defaults):
-        decky_plugin.logger.info("Get {}".format(key))
+        #decky_plugin.logger.info("Get {}".format(key))
         return settings.getSetting(key, defaults)
 
     async def settings_save(self, key: str, value):


### PR DESCRIPTION
This plugin makes log files up to several gigabytes in size mostly containing just the line `Get paddingBottom`, this is not only a storage issue but also makes journalctl logs very cluttered.
This PR comments out the line producing these logs as the only reason for having them seems to be debugging, and for that it could just be uncommented instead of included in release builds.